### PR TITLE
enable using the published npm package as CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-beta.7",
   "description": "JavaScript utilities to create .XKT files",
   "main": "index.js",
+  "bin": "/convert2xkt.js",
   "directories": {},
   "scripts": {
     "build-tests": "rollup --config rollup.config.tests.js",
@@ -72,6 +73,7 @@
     "puppeteer-firefox": "^0.5.1"
   },
   "files": [
-    "/dist"
+    "/dist",
+    "/convert2xkt.js"
   ]
 }


### PR DESCRIPTION
include `convert2xkt.js` in published package and use it as default entry point for CLI scripts in npm bin path