### PR TITLE
extract metadata & property sets from ifc file to JSON & read properties when import from gtlf

### DIFF
--- a/convert2xkt.js
+++ b/convert2xkt.js
@@ -14,9 +14,11 @@ program
     .option('-s, --source [file]', 'path to source file')
     .option('-f, --format [string]', 'source file format (optional); supported formats are gltf, ifc, laz, las, pcd, ply, stl and cityjson')
     .option('-m, --metamodel [file]', 'path to source metamodel JSON file (optional)')
+    .option('-z, --propsmetamodel [file]', 'path to source propsmetamodel JSON file (optional)')
     .option('-i, --include [types]', 'only convert these types (optional)')
     .option('-x, --exclude [types]', 'never convert these types (optional)')
     .option('-o, --output [file]', 'path to target .xkt file; creates directories on path automatically if not existing')
+    .option('-p, --outputmetaprops [file]', 'path to target .json file; creates directories on path automatically if not existing')
     .option('-l, --log', 'enable logging');
 
 program.on('--help', () => {
@@ -33,14 +35,14 @@ if (program.source === undefined) {
     process.exit(1);
 }
 
-if (program.output === undefined) {
-    console.error('Error: please specify target xkt file path.');
+if (program.output === undefined && program.outputmetaprops === undefined) {
+    console.error('Error: please specify target xkt or props file path.');
     program.help();
     process.exit(1);
 }
 
 function log(msg) {
-    if (options.log) {
+    if (program.log) {
         console.log(msg);
     }
 }
@@ -61,6 +63,8 @@ async function main() {
         output: program.output,
         includeTypes: program.include ? program.include.slice(",") : null,
         excludeTypes: program.exclude ? program.exclude.slice(",") : null,
+        outputProps: program.outputmetaprops,
+        propsMetaSource: program.propsmetamodel,
         log
     });
 

--- a/dist/xeokit-convert.cjs.js
+++ b/dist/xeokit-convert.cjs.js
@@ -58607,7 +58607,8 @@ function parseIFCIntoXKTModel({
                                   excludeTypes,
                                   wasmPath,
                                   stats = {},
-                                  log
+                                  log,
+                                  skipGeometry = false,
                               }) {
 
     return new Promise(function (resolve, reject) {
@@ -58685,7 +58686,9 @@ function parseIFCIntoXKTModel({
             ctx.xktModel.projectId = "" + ifcProjectId;
 
             parseMetadata(ctx);
-            parseGeometry(ctx);
+            if (!skipGeometry) {
+                parseGeometry(ctx);
+            }
             parsePropertySets(ctx);
 
             resolve();
@@ -58708,7 +58711,7 @@ function parsePropertySets(ctx) {
         let rel = ctx.ifcAPI.GetLine(ctx.modelID, relID, true);
 
         if (rel) {
-            
+
             const relatingPropertyDefinition = rel.RelatingPropertyDefinition;
             if (!relatingPropertyDefinition) {
                 continue;
@@ -81436,7 +81439,8 @@ function parseMetaModelIntoXKTModel({metaModelData, xktModel, includeTypes, excl
                 metaObjectId: metaObject.id,
                 metaObjectType: metaObject.type,
                 metaObjectName: metaObject.name,
-                parentMetaObjectId: metaObject.parent
+                parentMetaObjectId: metaObject.parent,
+                propertySetIds: metaObject.propertySetIds,
             });
 
             countMetaObjects++;

--- a/dist/xeokit-convert.es.js
+++ b/dist/xeokit-convert.es.js
@@ -58603,7 +58603,8 @@ function parseIFCIntoXKTModel({
                                   excludeTypes,
                                   wasmPath,
                                   stats = {},
-                                  log
+                                  log,
+                                  skipGeometry = false,
                               }) {
 
     return new Promise(function (resolve, reject) {
@@ -58681,7 +58682,9 @@ function parseIFCIntoXKTModel({
             ctx.xktModel.projectId = "" + ifcProjectId;
 
             parseMetadata(ctx);
-            parseGeometry(ctx);
+            if (!skipGeometry) {
+                parseGeometry(ctx);
+            }
             parsePropertySets(ctx);
 
             resolve();
@@ -58704,7 +58707,7 @@ function parsePropertySets(ctx) {
         let rel = ctx.ifcAPI.GetLine(ctx.modelID, relID, true);
 
         if (rel) {
-            
+
             const relatingPropertyDefinition = rel.RelatingPropertyDefinition;
             if (!relatingPropertyDefinition) {
                 continue;
@@ -81432,7 +81435,8 @@ function parseMetaModelIntoXKTModel({metaModelData, xktModel, includeTypes, excl
                 metaObjectId: metaObject.id,
                 metaObjectType: metaObject.type,
                 metaObjectName: metaObject.name,
-                parentMetaObjectId: metaObject.parent
+                parentMetaObjectId: metaObject.parent,
+                propertySetIds: metaObject.propertySetIds,
             });
 
             countMetaObjects++;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xeokit/xeokit-convert",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xeokit/xeokit-convert",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.9",
       "license": "LICENSE",
       "dependencies": {
         "@loaders.gl/core": "^3.0.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xeokit/xeokit-convert",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xeokit/xeokit-convert",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0-beta.8",
       "license": "LICENSE",
       "dependencies": {
         "@loaders.gl/core": "^3.0.13",
@@ -7779,10 +7779,8 @@
       "integrity": "sha512-6+iaCMh/JXJaB2QWikqvGE9//wLEVYYwZd5sud8aLoLKog1Q75naZh2vlGVtg5Mq/NqpqGQvdIjJb3Bm+64AUQ==",
       "dev": true,
       "requires": {
-        "@oclif/config": "^1",
         "@oclif/errors": "^1.2.2",
         "@oclif/parser": "^3.8.3",
-        "@oclif/plugin-help": "^2",
         "debug": "^4.1.1",
         "semver": "^5.6.0"
       },
@@ -8133,7 +8131,6 @@
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "dev": true,
           "requires": {
-            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xeokit/xeokit-convert",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "JavaScript utilities to create .XKT files",
   "main": "index.js",
   "bin": "/convert2xkt.js",
@@ -64,13 +64,13 @@
     "esdoc-standard-plugin": "^1.0.0",
     "http-server": "^0.12.3",
     "puppeteer": "^10.2.0",
+    "puppeteer-firefox": "^0.5.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.46.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-minify-es": "^1.1.1",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "puppeteer-firefox": "^0.5.1"
+    "rollup-plugin-node-resolve": "^5.2.0"
   },
   "files": [
     "/dist",

--- a/src/parsers/parseIFCIntoXKTModel.js
+++ b/src/parsers/parseIFCIntoXKTModel.js
@@ -52,7 +52,8 @@ function parseIFCIntoXKTModel({
                                   excludeTypes,
                                   wasmPath,
                                   stats = {},
-                                  log
+                                  log,
+                                  skipGeometry = false,
                               }) {
 
     return new Promise(function (resolve, reject) {
@@ -130,7 +131,9 @@ function parseIFCIntoXKTModel({
             ctx.xktModel.projectId = "" + ifcProjectId;
 
             parseMetadata(ctx);
-            parseGeometry(ctx);
+            if (!skipGeometry) {
+                parseGeometry(ctx);
+            }
             parsePropertySets(ctx);
 
             resolve();
@@ -153,7 +156,7 @@ function parsePropertySets(ctx) {
         let rel = ctx.ifcAPI.GetLine(ctx.modelID, relID, true);
 
         if (rel) {
-            
+
             const relatingPropertyDefinition = rel.RelatingPropertyDefinition;
             if (!relatingPropertyDefinition) {
                 continue;

--- a/src/parsers/parseMetaModelIntoXKTModel.js
+++ b/src/parsers/parseMetaModelIntoXKTModel.js
@@ -58,7 +58,8 @@ function parseMetaModelIntoXKTModel({metaModelData, xktModel, includeTypes, excl
                 metaObjectId: metaObject.id,
                 metaObjectType: metaObject.type,
                 metaObjectName: metaObject.name,
-                parentMetaObjectId: metaObject.parent
+                parentMetaObjectId: metaObject.parent,
+                propertySetIds: metaObject.propertySetIds,
             });
 
             countMetaObjects++;


### PR DESCRIPTION
read metadata & property sets from JSON file and merge with geometry for gltf file.

this removes the need for the xeokit-metadata in dotnet and also saves the propertySets.

this branch was created on top of the tag: 1.0.0-beta.8