### PR TITLE
Peformance improvement: avoid expensive `glTF` data loading/decoding.

### DIFF
--- a/src/parsers/parseGLTFIntoXKTModel.js
+++ b/src/parsers/parseGLTFIntoXKTModel.js
@@ -130,6 +130,16 @@ function parseBuffers(ctx) {  // Parses geometry buffers into temporary  "_buffe
 
 function parseBuffer(ctx, bufferInfo) {
     return new Promise(function (resolve, reject) {
+        // Allow a shortcut where the glTF buffer is "enrichened" with direct
+        // access to the data-arrayBuffer, w/out needing to either:
+        // - read the file indicated by the ".uri" component of the buffer
+        // - base64-decode the encoded data in the ".uri" component
+        if (bufferInfo._arrayBuffer) {
+            bufferInfo._buffer = bufferInfo._arrayBuffer;
+            resolve (bufferInfo);
+            return;
+        }
+        // Otherwise, proceed with "standard-glTF" .uri component.
         const uri = bufferInfo.uri;
         if (!uri) {
             reject('gltf/handleBuffer missing uri in ' + JSON.stringify(bufferInfo));


### PR DESCRIPTION
This change allows, when passing an object corresponding to a glTF document, to avoid the need of either:

- have the `buffer.uri` component to point to a file in disk
- have the `buffer.uri` component to need a base64-decode process

This _shortcut_ works really well together with https://github.com/donmccurdy/glTF-Transform, in order to programmatically generate the glTF document in-memory in high performance conversion scenarios.

In the consuming side of `xeokit-convert`, when using `glTF-Transform` to generate the `glTF` documents, the change in this commit allows for major RAM/speed improvements, while keeping the whole `glTF` document in-memory (which is anyway necessary for `xeokit-convert` to parse the `glTF` into the `XktModel`), thanks to the following auxiliary code:

```js
var jsonDocument = nodeIO.writeJSON(document);

// a) embed binary resources in a new key called "arrayBuffer" in the glTF JSON document
// This avoids to base-64-encode the binary buffers, or writing to additional in-disk files,
// which solves memory problems in models with massive geometry
// (due to not enough memory for the large base64-strings).
var resourceKeys = Object.keys(jsonDocument.resources);

for (var i = 0; i < resourceKeys.length; i++)
{
    var resourceKey = resourceKeys[i];

    for (var j = 0; j < jsonDocument.json.buffers.length; j++)
    {
        var buffer = jsonDocument.json.buffers [j];

        if (buffer.uri === resourceKey)
        {
            // This additional "._arrayBuffer" key is what will be received by `xeokit-convert`
            // after the change in this PR 🎉
            buffer._arrayBuffer = jsonDocument.resources[resourceKey];

            jsonDocument.resources[resourceKey] = null;
        }
    }
}
```