### PR TITLE
Make sure to export `.external` attribute for `MetaObject` JSON DTO

### DIFF
--- a/src/XKTModel/writeXKTModelToArrayBuffer.js
+++ b/src/XKTModel/writeXKTModelToArrayBuffer.js
@@ -166,6 +166,9 @@ function getModelData(xktModel) {
         if (metaObject.propertySetIds && metaObject.propertySetIds.length > 0) {
             metaObjectJSON.propertySetIds = metaObject.propertySetIds;
         }
+        if (metaObject.external) {
+            metaObjectJSON.external = metaObject.external;
+        }
         data.metadata.metaObjects.push(metaObjectJSON);
     }
 


### PR DESCRIPTION
Right now, when loading XKT files in [xeokit/xeokit-sdk](https://github.com/xeokit/xeokit-sdk), the [MetaObject](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/metadata/MetaObject.js) class will load `external` data from the `XKT` files if they provide the `external` attribute in the scene metadata:

https://github.com/xeokit/xeokit-sdk/blob/968828eeb2dee9955f5a24dd2164e555e8938ead/src/viewer/metadata/MetaObject.js#L100-L111

```js
if (external !== undefined && external !== null) {

    /**
     * External application-specific metadata
     *
     * Undefined when there are is no external application-specific metadata.
     *
     * @property external
     * @type {*}
     */
    this.external = external;
}
```

This PR makes sure that, when writing the `XKT` file from [writeXKTModelToArrayBuffer.js](https://github.com/xeokit/xeokit-convert/blob/main/src/XKTModel/writeXKTModelToArrayBuffer.js), the `external` data is written to the `XKT` file in case the `XKTMetaObject` has it set.