### PR TITLE
Improve memory performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xeokit/xeokit-convert",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "JavaScript utilities to create .XKT files",
   "main": "index.js",
   "bin": "/convert2xkt.js",


### PR DESCRIPTION
### Description

This PR makes ````convert2xkt```` use less memory as it processes metadata JSON files.

### Issue

As reported in #70 and #72,  ````convert2xkt```` sometimes runs out of memory when converting ````glTF```` with a large metadata ````JSON```` file. An example log is shown below.


````bash
[convert2xkt] Running convert2xkt v1.1.0...
[convert2xkt] Reading input file: myHugeModel.glb
[convert2xkt] Input file size: 488709.84 kB
[convert2xkt] Reading input metadata file: myHugeModel.json
...
FATAL ERROR: invalid table size Allocation failed - JavaScript heap out of memory
...
Aborted
````

### Cause 

Within ````convert2xkt````, we're doing some unnecessary processing of the metadata JSON, which creates a bunch unnecessary memory pressure.

When ````convert2xkt```` converts ````glTF```` and ````JSON```` metadata files into ````XKT````, it internally parses the metadata into the ````XKTModel````, then as it serializes the ````XKTModel```` out to an ````XKT```` file, it converts that metadata back to a JSON string, and embeds that in the metadata section of the ````XKT````. 
 
When converting a large metadata file, ````convert2xkt```` therefore sometimes crashes at the last step (conversion of metadata back to JSON string).

### Fix

This PR simplifies the processing of metadata JSON: when ````convert2xkt```` converts ````glTF```` and ````JSON```` metadata files into ````XKT````, we now just copy the metadata, as an arraybuffer, straight into the metadata section of the ````XKT````. 


