### PR TITLE
Support split file output from ifc2gltf

### DIFF
--- a/convert2xkt.js
+++ b/convert2xkt.js
@@ -6,6 +6,7 @@ const {convert2xkt, XKT_INFO} = require("./dist/xeokit-convert.cjs.js");
 const fs = require('fs');
 
 const WebIFC = require("web-ifc/web-ifc-api-node.js");
+const path = require("path");
 
 const program = new commander.Command();
 
@@ -13,6 +14,7 @@ program.version(npmPackage.version, '-v, --version');
 
 program
     .option('-s, --source [file]', 'path to source file')
+    .option('-a, --sourcemanifest [file]', 'path to source manifest file')
     .option('-f, --format [string]', 'source file format (optional); supported formats are gltf, ifc, laz, las, pcd, ply, stl and cityjson')
     .option('-m, --metamodel [file]', 'path to source metamodel JSON file (optional)')
     .option('-i, --include [types]', 'only convert these types (optional)')
@@ -33,8 +35,8 @@ program.parse(process.argv);
 
 const options = program.opts();
 
-if (options.source === undefined) {
-    console.error('Error: please specify source file path.');
+if (options.source === undefined && options.sourcemanifest === undefined) {
+    console.error('Error: please specify path to source file or manifest.');
     program.help();
     process.exit(1);
 }
@@ -52,34 +54,141 @@ function log(msg) {
 }
 
 async function main() {
-    if (options.output) {
+
+    if (options.sourcemanifest) {
+
+        log(`[convert2xkt] Running convert2xkt v${npmPackage.version}...`);
+        log(`[convert2xkt] Converting glTF files in manifest ${options.sourcemanifest}...`);
+
+        let manifestData = fs.readFileSync(options.sourcemanifest);
+        let manifest = JSON.parse(manifestData);
+
+        if (!manifest.gltfOutFiles) {
+            console.error(`Error: Input manifest invalid - missing field: gltfOutFiles`);
+            process.exit(1);
+        }
+
+        if (!manifest.metadataOutFiles) {
+            console.error(`Error: Input manifest invalid - missing field: metadataOutFiles`);
+            process.exit(1);
+        }
+
+        const numInputFiles = manifest.gltfOutFiles.length;
+
+        if (numInputFiles === 0) {
+            console.error(`Error: Input manifest invalid - gltfOutFiles is zero length`);
+            process.exit(1);
+        }
+
+        if (numInputFiles !== manifest.metadataOutFiles.length) {
+            console.error(`Error: Input manifest invalid - length of gltfOutFiles and metadataOutFiles don't match`);
+            process.exit(1);
+        }
+
         const outputDir = getBasePath(options.output).trim();
         if (outputDir !== "" && !fs.existsSync(outputDir)) {
             fs.mkdirSync(outputDir, {recursive: true});
         }
+
+        function formatDate(date) {
+            const year = date.getFullYear();
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const day = String(date.getDate()).padStart(2, '0');
+            const hours = String(date.getHours()).padStart(2, '0');
+            const minutes = String(date.getMinutes()).padStart(2, '0');
+            const seconds = String(date.getSeconds()).padStart(2, '0');
+            return `${day}-${month}-${year}- ${hours}-${minutes}-${seconds}`;
+        }
+
+        const xktManifest = {
+            inputFile: options.sourcemanifest,
+            converterApplication: "convert2xkt",
+            converterApplicationVersion: `v${npmPackage.version}`,
+            conversionDate: formatDate(new Date()),
+            outputDir: options.output,
+            xktFiles: []
+        };
+
+        let i = 0;
+
+        const convertNextFile = () => {
+
+            const source = manifest.gltfOutFiles[i];
+            const metaModelSource = manifest.metadataOutFiles[i];
+            const output = path.join(options.output, `model${i}.xkt`);
+
+            convert2xkt({
+                WebIFC,
+                source,
+                format: "gltf",
+                metaModelSource,
+                output: path.join(options.output, `model${i}.xkt`),
+                includeTypes: options.include ? options.include.slice(",") : null,
+                excludeTypes: options.exclude ? options.exclude.slice(",") : null,
+                rotateX: options.rotatex,
+                reuseGeometries: (options.disablegeoreuse !== true),
+                minTileSize: options.mintilesize,
+                includeTextures: options.textures,
+                includeNormals: options.normals,
+                log
+            }).then(() => {
+
+                i++;
+
+                log(`[convert2xkt] Converted model${i}.xkt (${i} of ${numInputFiles})`);
+
+                xktManifest.xktFiles.push(`model${i}.xkt`);
+
+                if (i === numInputFiles) {
+                    fs.writeFileSync(path.join(options.output, `xkt.manifest.json`), JSON.stringify(xktManifest));
+                    log(`[convert2xkt] Done.`);
+                    process.exit(0);
+                } else {
+                    convertNextFile();
+                }
+
+            }).catch((err) => {
+                console.error(`Error: ${err}`);
+                process.exit(1);
+            });
+        }
+
+        convertNextFile();
+
+    } else {
+
+        if (options.output) {
+            const outputDir = getBasePath(options.output).trim();
+            if (outputDir !== "" && !fs.existsSync(outputDir)) {
+                fs.mkdirSync(outputDir, {recursive: true});
+            }
+        }
+
+        log(`[convert2xkt] Running convert2xkt v${npmPackage.version}...`);
+        log(`[convert2xkt] Converting single input file ${options.source}...`);
+
+        convert2xkt({
+            WebIFC,
+            source: options.source,
+            format: options.format,
+            metaModelSource: options.metamodel,
+            output: options.output,
+            includeTypes: options.include ? options.include.slice(",") : null,
+            excludeTypes: options.exclude ? options.exclude.slice(",") : null,
+            rotateX: options.rotatex,
+            reuseGeometries: (options.disablegeoreuse !== true),
+            minTileSize: options.mintilesize,
+            includeTextures: options.textures,
+            includeNormals: options.normals,
+            log
+        }).then(() => {
+            log(`[convert2xkt] Done.`);
+            process.exit(0);
+        }).catch((err) => {
+            console.error(`Error: ${err}`);
+            process.exit(1);
+        });
     }
-    log(`[convert2xkt] Running convert2xkt v${npmPackage.version}...`);
-    convert2xkt({
-        WebIFC,
-        source: options.source,
-        format: options.format,
-        metaModelSource: options.metamodel,
-        output: options.output,
-        includeTypes: options.include ? options.include.slice(",") : null,
-        excludeTypes: options.exclude ? options.exclude.slice(",") : null,
-        rotateX: options.rotatex,
-        reuseGeometries: (options.disablegeoreuse !== true),
-        minTileSize: options.mintilesize,
-        includeTextures: options.textures,
-        includeNormals: options.normals,
-        log
-    }).then(() => {
-        log(`[convert2xkt] Done.`);
-        process.exit(0);
-    }).catch((err) => {
-        console.error(`Error: ${err}`);
-        process.exit(1);
-    });
 }
 
 function getBasePath(src) {

--- a/convert2xkt.js
+++ b/convert2xkt.js
@@ -115,14 +115,16 @@ async function main() {
 
             const source = manifest.gltfOutFiles[i];
             const metaModelSource = manifest.metadataOutFiles[i];
-            const output = path.join(options.output, `model${i}.xkt`);
+            const outputFileName = getFileNameWithoutExtension(source);
+
+            const outputFileNameXKT = `${outputFileName}.xkt`;
 
             convert2xkt({
                 WebIFC,
                 source,
                 format: "gltf",
                 metaModelSource,
-                output: path.join(options.output, `model${i}.xkt`),
+                output: path.join(options.output, outputFileNameXKT),
                 includeTypes: options.include ? options.include.slice(",") : null,
                 excludeTypes: options.exclude ? options.exclude.slice(",") : null,
                 rotateX: options.rotatex,
@@ -137,7 +139,7 @@ async function main() {
 
                 log(`[convert2xkt] Converted model${i}.xkt (${i} of ${numInputFiles})`);
 
-                xktManifest.xktFiles.push(`model${i}.xkt`);
+                xktManifest.xktFiles.push(outputFileNameXKT);
 
                 if (i === numInputFiles) {
                     fs.writeFileSync(path.join(options.output, `xkt.manifest.json`), JSON.stringify(xktManifest));
@@ -194,6 +196,12 @@ async function main() {
 function getBasePath(src) {
     const i = src.lastIndexOf("/");
     return (i !== 0) ? src.substring(0, i + 1) : "";
+}
+
+function getFileNameWithoutExtension(filePath) {
+    const baseName = path.basename(filePath);
+    const fileNameWithoutExtension = path.parse(baseName).name;
+    return fileNameWithoutExtension;
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Description

This PR extends ````convert2xkt```` with the ability to convert the output ````ifc2gltf```` when the latter is used in split-output mode.

## Usage

Run ````ifc2gltf```` with the ````-s```` option, to convert an IFC file into a set of multiple ````glb```` geometry and ````json```` metadata files:  

````
ifc2gltfcxconverter -i model.ifc -o myGLBFiles/model.glb -m myGLBFiles/model.json -s 5 -e 3
````

The ````-s 5```` option causes ````ifc2gltf```` to split the output into these multiple files, each no bigger than 5Gb.

The contents of the ````myGLBFiles```` directory then looks like this:

````
myGLBFiles
├── model.glb
├── model.json
├── model_1.glb
├── model_1.json
├── model_2.glb
├── model_2.json
├── model_3.glb
├── model_3.json
└── model.glb.manifest.json
````

Now run ````convert2xkt```` with the new ````-a```` option, pointing to the ````myGLBFiles/model.glb.manifest.json```` file:

````bash
node convert2xkt.js -a myGLBFiles/model.glb.manifest.json -o myXKTFiles -l
````

The contents of ````myXKTFiles```` now look like this:

````
myXKTFiles
├── model.xkt
├── model_1.xkt
├── model_2.xkt
├── model_3.xkt
└── model.xkt.manifest.json
````

The ````model.xkt.manifest```` file looks like this:

````json
{
  "inputFile": "/absolute/path/myGLBFiles/model.glb.manifest.json",
  "converterApplication": "convert2xkt",
  "converterApplicationVersion": "v1.1.8",
  "conversionDate": "09-08-2023- 23-53-30",
  "outputDir": "/absolute/path/myXKTFiles",
  "xktFiles": [
    "model.xkt",
    "model_1.xkt",
    "model_2.xkt",
    "model_3.xkt"
  ]
}
````