### PR TITLE
Fix conversion of manifests with external metamodels

### DIFF
--- a/convert2xkt.conf.js
+++ b/convert2xkt.conf.js
@@ -29,7 +29,7 @@ module.exports = {
             "colorDepth": "auto",   // 8, 16 or "auto"
             "fp64": true,           // Expect 64-bit color values
             "skip": 1,              // Convert every nth point (default = 1)
-            "minTileSize": 200      // Minimum RTC tile (default = 200)
+            "minTileSize": 1000      // Minimum RTC tile (default = 1000)
         },
 
         "laz": {
@@ -43,7 +43,7 @@ module.exports = {
             "colorDepth": "auto",
             "fp64": true,
             "skip": 1,
-            "minTileSize": 200
+            "minTileSize": 1000
         },
 
         //----------------------------------------------------------------------------
@@ -96,7 +96,7 @@ module.exports = {
             // (i.e. more draw calls). We recommend using the default value unless you get
             // precision problems when rendering (i.e. jittering, or misalignment of objects).
 
-            "minTileSize": 200,
+            "minTileSize": 1000,
 
             // When converting .gltf source files that are accompanied by metadata JSON
             // files, this will cause the metadata JSON files to not be embedded within the XKT output
@@ -136,7 +136,7 @@ module.exports = {
                 0.0, 1.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 1.0
             ],
-            "minTileSize": 200
+            "minTileSize": 1000
         }
     }
 }

--- a/convert2xkt.conf.json
+++ b/convert2xkt.conf.json
@@ -11,7 +11,7 @@
             "colorDepth": "auto",
             "fp64": true,
             "skip": 1,
-            "minTileSize": 200
+            "minTileSize": 1000
         },
         "laz": {
             "center": false,
@@ -24,18 +24,18 @@
             "colorDepth": "auto",
             "fp64": true,
             "skip": 1,
-            "minTileSize": 200
+            "minTileSize": 1000
         },
         "ifc": {
             "excludeTypes": [],
-            "minTileSize": 200
+            "minTileSize": 1000
         },
         "gltf": {
             "reuseGeometries": true,
             "includeTextures": true,
             "includeNormals": false,
             "excludeTypes": [],
-            "minTileSize": 200,
+            "minTileSize": 1000,
             "externalMetadata": true
         },
         "glb": {
@@ -43,7 +43,7 @@
             "includeTextures": true,
             "includeNormals": false,
             "excludeTypes": [],
-            "minTileSize": 200,
+            "minTileSize": 1000,
             "externalMetadata": true
         },
         "json": {
@@ -54,7 +54,7 @@
                 0.0, 1.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 1.0
             ],
-            "minTileSize": 200
+            "minTileSize": 1000
         }
     }
 }

--- a/convert2xkt.js
+++ b/convert2xkt.js
@@ -28,7 +28,7 @@ program
     .option('-x, --exclude [types]', 'never convert these types (optional)')
     .option('-r, --rotatex', 'rotate model 90 degrees about X axis (for las and cityjson)')
     .option('-g, --disablegeoreuse', 'disable geometry reuse (optional)')
-    .option('-z, --mintilesize [number]', 'minimum diagonal tile size (optional, default 500)')
+    .option('-z, --minTileSize [number]', 'minimum diagonal tile size (optional, default 500)')
     .option('-t, --disabletextures', 'ignore textures (optional)')
     .option('-n, --disablenormals', 'ignore normals (optional)')
     .option('-o, --output [file]', 'path to target .xkt file when -s option given, or JSON manifest for multiple .xkt files when source manifest file given with -a; creates directories on path automatically if not existing')
@@ -149,18 +149,30 @@ async function main() {
             const outputFileName = getFileNameWithoutExtension(source);
             const outputFileNameXKT = `${outputFileName}.xkt`;
 
+            let modelAABB;
+            // if (manifest.modelBoundsMin && manifest.modelBoundsMax) {
+            //     modelAABB= [
+            //         manifest.modelBoundsMin[0],
+            //         manifest.modelBoundsMin[1],
+            //         manifest.modelBoundsMin[2],
+            //         manifest.modelBoundsMax[0],
+            //         manifest.modelBoundsMax[1],
+            //         manifest.modelBoundsMax[2]
+            //     ];
+            // }
             convert2xkt({
                 WebIFC,
                 configs,
                 source,
                 format: "gltf",
                 metaModelSource: (!externalMetadata) ? metaModelSource : null,
+                modelAABB,
                 output: path.join(outputDir, outputFileNameXKT),
                 includeTypes: options.include ? options.include.slice(",") : null,
                 excludeTypes: options.exclude ? options.exclude.slice(",") : null,
                 rotateX: options.rotatex,
                 reuseGeometries: (options.disablegeoreuse !== true),
-                minTileSize: options.mintilesize,
+                minTileSize: options.minTileSize,
                 includeTextures: !options.disabletextures,
                 includeNormals: !options.disablenormals,
                 log
@@ -210,7 +222,7 @@ async function main() {
             excludeTypes: options.exclude ? options.exclude.slice(",") : null,
             rotateX: options.rotatex,
             reuseGeometries: (options.disablegeoreuse !== true),
-            minTileSize: options.mintilesize,
+            minTileSize: options.minTileSize,
             includeTextures: !options.disabletextures,
             includeNormals: !options.disablenormals,
             log

--- a/src/convert2xkt.js
+++ b/src/convert2xkt.js
@@ -80,6 +80,7 @@ function convert2xkt({
                          sourceFormat,
                          metaModelSource,
                          metaModelDataStr,
+                         modelAABB,
                          output,
                          outputXKTModel,
                          outputXKT,
@@ -192,6 +193,7 @@ function convert2xkt({
             try {
                 metaModelJSON = JSON.parse(metaModelDataStr);
             } catch (e) {
+                metaModelJSON = {};
                 log(`Error parsing metadata JSON: ${e}`);
             }
         }
@@ -209,7 +211,8 @@ function convert2xkt({
         }
 
         const xktModel = new XKTModel({
-            minTileSize
+            minTileSize,
+            modelAABB
         });
 
         switch (ext) {
@@ -356,6 +359,7 @@ function convert2xkt({
             parser(converterParams).then(() => {
 
                 if (!metaModelJSON) {
+                    log("Creating default metamodel in XKT");
                     xktModel.createDefaultMetaObjects();
                 }
 
@@ -399,6 +403,7 @@ function convert2xkt({
                     log("Converted vertices: " + stats.numVertices);
                     log("Converted UVs: " + stats.numUVs);
                     log("Converted normals: " + stats.numNormals);
+                    log("Converted tiles: " + xktModel.tilesList.length);
                     log("minTileSize: " + stats.minTileSize);
 
                     if (output) {


### PR DESCRIPTION
* Fixes a bug where when converting a manifest of multiple `.glb` and metamodel JSON files, `convert2xkt` was also creating default metaobjects.
* Optimizes tiling to ensure minimum number of RTC tiles are created for split `.glb` and `JSON` files.


