### PR TITLE
[FIX] Convert nested named glTF nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xeokit/xeokit-convert",
-  "version": "1.1.15-beta-12",
+  "version": "1.1.15",
   "description": "JavaScript utilities to create .XKT files",
   "main": "index.js",
   "bin": "/convert2xkt.js",

--- a/src/parsers/parseGLTFIntoXKTModel.js
+++ b/src/parsers/parseGLTFIntoXKTModel.js
@@ -100,7 +100,7 @@ function parseGLTFIntoXKTModel({
 
             const ctx = {
                 gltfData,
-                metaModelCorrections: metaModelData ? getMetaModelCorrections(metaModelData) : null,
+                metaModelCorrections: metaModelData,
                 getAttachment: getAttachment || (() => {
                     throw new Error('You must define getAttachment() method to convert glTF with external resources')
                 }),
@@ -133,42 +133,6 @@ function parseGLTFIntoXKTModel({
             reject(`[parseGLTFIntoXKTModel] ${errMsg}`);
         });
     });
-}
-
-function getMetaModelCorrections(metaModelData) {
-    const eachRootStats = {};
-    const eachChildRoot = {};
-    const metaObjects = metaModelData.metaObjects || [];
-    const metaObjectsMap = {};
-    for (let i = 0, len = metaObjects.length; i < len; i++) {
-        const metaObject = metaObjects[i];
-        metaObjectsMap[metaObject.id] = metaObject;
-    }
-    for (let i = 0, len = metaObjects.length; i < len; i++) {
-        const metaObject = metaObjects[i];
-        if (metaObject.parent !== undefined && metaObject.parent !== null) {
-            const metaObjectParent = metaObjectsMap[metaObject.parent];
-            if (metaObject.type === metaObjectParent.type) {
-                let rootMetaObject = metaObjectParent;
-                while (rootMetaObject.parent && metaObjectsMap[rootMetaObject.parent].type === rootMetaObject.type) {
-                    rootMetaObject = metaObjectsMap[rootMetaObject.parent];
-                }
-                const rootStats = eachRootStats[rootMetaObject.id] || (eachRootStats[rootMetaObject.id] = {
-                    numChildren: 0,
-                    countChildren: 0
-                });
-                rootStats.numChildren++;
-                eachChildRoot[metaObject.id] = rootMetaObject;
-            } else {
-
-            }
-        }
-    }
-    return {
-        metaObjectsMap,
-        eachRootStats,
-        eachChildRoot
-    };
 }
 
 function parseTextures(ctx) {


### PR DESCRIPTION
When `convert2xkt` parses the `scene` hierarchy within `glTF`, at each `node`, it expects a name attribute only if that node represents an IFC element.

This PR extends the parsing to allow nested `nodes` with `name` attributes. This allows it to convert aggregations of IFC elements in which both parents and children can have geometry.

