### PR TITLE
Implement xkt's V11 export

### DIFF
--- a/convert2xkt.js
+++ b/convert2xkt.js
@@ -31,6 +31,7 @@ program
     .option('-z, --minTileSize [number]', 'minimum diagonal tile size (optional, default 500)')
     .option('-t, --disabletextures', 'ignore textures (optional)')
     .option('-n, --disablenormals', 'ignore normals (optional)')
+    .option('-u, --uncompressBuffers', 'do not compress buffers, otherwise output xkt V10 with compressed buffers (optional)')
     .option('-o, --output [file]', 'path to target .xkt file when -s option given, or JSON manifest for multiple .xkt files when source manifest file given with -a; creates directories on path automatically if not existing')
     .option('-l, --log', 'enable logging (optional)');
 
@@ -184,6 +185,7 @@ async function main() {
                 minTileSize: options.minTileSize,
                 includeTextures: !options.disabletextures,
                 includeNormals: !options.disablenormals,
+                zip: !options.uncompressBuffers,
                 log
             }).then(() => {
 
@@ -234,6 +236,7 @@ async function main() {
             minTileSize: options.minTileSize,
             includeTextures: !options.disabletextures,
             includeNormals: !options.disablenormals,
+            zip: !options.uncompressBuffers,
             log
         }).then(() => {
             log(`[convert2xkt] Done.`);

--- a/src/XKT_INFO.js
+++ b/src/XKT_INFO.js
@@ -15,7 +15,7 @@ const XKT_INFO = {
      * @property xktVersion
      * @type {number}
      */
-    xktVersion: 10
+    xktVersion: 11
 };
 
 export {XKT_INFO};

--- a/src/convert2xkt.js
+++ b/src/convert2xkt.js
@@ -93,6 +93,7 @@ function convert2xkt({
                          rotateX = false,
                          includeTextures = true,
                          includeNormals = true,
+                         zip = true,
                          log = function (msg) {
                          }
                      }) {
@@ -381,7 +382,7 @@ function convert2xkt({
 
                     log("XKT document built OK. Writing to XKT file...");
 
-                    const xktArrayBuffer = writeXKTModelToArrayBuffer(xktModel, metaModelJSON, stats, {zip: true});
+                    const xktArrayBuffer = writeXKTModelToArrayBuffer(xktModel, metaModelJSON, stats, {zip: zip});
 
                     const xktContent = Buffer.from(xktArrayBuffer);
 
@@ -390,7 +391,7 @@ function convert2xkt({
                     stats.minTileSize = minTileSize || 200;
                     stats.sourceSize = (sourceFileSizeBytes / 1000).toFixed(2);
                     stats.xktSize = (targetFileSizeBytes / 1000).toFixed(2);
-                    stats.xktVersion = XKT_INFO.xktVersion;
+                    stats.xktVersion = zip ? 10 : XKT_INFO.xktVersion;
                     stats.compressionRatio = (sourceFileSizeBytes / targetFileSizeBytes).toFixed(2);
                     stats.conversionTime = ((new Date() - startTime) / 1000.0).toFixed(2);
                     stats.aabb = xktModel.aabb;


### PR DESCRIPTION
This PR implements V11 uncompressed data format, hidden behind the `-u, --uncompressBuffers` command line flag, but falling back to V10 by default.