### PR TITLE
[FIX] First argument to DataView constructor must be an ArrayBuffer

### DIFF
--- a/src/parsers/parseSTLIntoXKTModel.js
+++ b/src/parsers/parseSTLIntoXKTModel.js
@@ -337,9 +337,9 @@ function ensureBinary(buffer) {
         for (let i = 0; i < buffer.length; i++) {
             arrayBuffer[i] = buffer.charCodeAt(i) & 0xff; // implicitly assumes little-endian
         }
-        return arrayBuffer.buffer || arrayBuffer;
+        return arrayBuffer.buffer;
     } else {
-        return buffer;
+        return buffer.buffer;
     }
 }
 


### PR DESCRIPTION
DataView can't use other types that were not an ArrayBuffer, so it crashed during the conversion with such log error.

Related to XCD-195 and probably to this one: https://github.com/xeokit/xeokit-convert/issues/52