### PR TITLE
Extend gltfToXktConvert to handle extras attribute for IfcAxisLabels

### DIFF
--- a/convert2xkt.js
+++ b/convert2xkt.js
@@ -31,7 +31,7 @@ program
     .option('-z, --minTileSize [number]', 'minimum diagonal tile size (optional, default 500)')
     .option('-t, --disabletextures', 'ignore textures (optional)')
     .option('-n, --disablenormals', 'ignore normals (optional)')
-    .option('-u, --uncompressBuffers', 'do not compress buffers, otherwise output xkt V10 with compressed buffers (optional)')
+    .option('-b, --compressBuffers', 'compress buffers (optional)')
     .option('-o, --output [file]', 'path to target .xkt file when -s option given, or JSON manifest for multiple .xkt files when source manifest file given with -a; creates directories on path automatically if not existing')
     .option('-l, --log', 'enable logging (optional)');
 
@@ -179,7 +179,7 @@ async function main() {
                 minTileSize: options.minTileSize,
                 includeTextures: !options.disabletextures,
                 includeNormals: !options.disablenormals,
-                zip: !options.uncompressBuffers,
+                zip: options.compressBuffers,
                 log
             }).then(() => {
 
@@ -230,7 +230,7 @@ async function main() {
             minTileSize: options.minTileSize,
             includeTextures: !options.disabletextures,
             includeNormals: !options.disablenormals,
-            zip: !options.uncompressBuffers,
+            zip: options.compressBuffers,
             log
         }).then(() => {
             log(`[convert2xkt] Done.`);

--- a/src/XKTModel/XKTGeometry.js
+++ b/src/XKTModel/XKTGeometry.js
@@ -14,6 +14,7 @@ class XKTGeometry {
      * @param {*} cfg Configuration for the XKTGeometry.
      * @param {Number} cfg.geometryId Unique ID of the geometry in {@link XKTModel#geometries}.
      * @param {String} cfg.primitiveType Type of this geometry - "triangles", "points" or "lines" so far.
+     * @param {String} cfg.axisLabel Text label of this geometry - "A", "B1"
      * @param {Number} cfg.geometryIndex Index of this XKTGeometry in {@link XKTModel#geometriesList}.
      * @param {Float64Array} cfg.positions Non-quantized 3D vertex positions.
      * @param {Float32Array} cfg.normals Non-compressed vertex normals.
@@ -37,6 +38,13 @@ class XKTGeometry {
          * @type {String}
          */
         this.primitiveType = cfg.primitiveType;
+
+        /**
+         * The text label - "A", "B1".
+         *
+         * @type {String}
+         */
+        this.axisLabel = cfg.axisLabel;
 
         /**
          * Index of this XKTGeometry in {@link XKTModel#geometriesList}.

--- a/src/XKTModel/XKTModel.js
+++ b/src/XKTModel/XKTModel.js
@@ -707,13 +707,14 @@ class XKTModel {
 
         const triangles = params.primitiveType === "triangles";
         const points = params.primitiveType === "points";
+        const axis_label = params.primitiveType === "axis-label";
         const lines = params.primitiveType === "lines";
         const line_strip = params.primitiveType === "line-strip";
         const line_loop = params.primitiveType === "line-loop";
         const triangle_strip = params.primitiveType === "triangle-strip";
         const triangle_fan = params.primitiveType === "triangle-fan";
 
-        if (!triangles && !points && !lines && !line_strip && !line_loop) {
+        if (!triangles && !points && !lines && !line_strip && !line_loop && !axis_label) {
             throw "[XKTModel.createGeometry] Unsupported value for params.primitiveType: "
             + params.primitiveType
             + "' - supported values are 'triangles', 'points', 'lines', 'line-strip', 'triangle-strip' and 'triangle-fan";
@@ -751,12 +752,14 @@ class XKTModel {
 
         const geometryId = params.geometryId;
         const primitiveType = params.primitiveType;
+        const axisLabel = params.axisLabel;
         const positions = new Float64Array(params.positions); // May modify in #finalize
 
         const xktGeometryCfg = {
             geometryId: geometryId,
             geometryIndex: this.geometriesList.length,
             primitiveType: primitiveType,
+            axisLabel,
             positions: positions,
             uvs: params.uvs || params.uv
         }

--- a/src/XKT_INFO.js
+++ b/src/XKT_INFO.js
@@ -15,7 +15,7 @@ const XKT_INFO = {
      * @property xktVersion
      * @type {number}
      */
-    xktVersion: 11
+    xktVersion: 12
 };
 
 export {XKT_INFO};

--- a/src/convert2xkt.js
+++ b/src/convert2xkt.js
@@ -93,7 +93,7 @@ function convert2xkt({
                          rotateX = false,
                          includeTextures = true,
                          includeNormals = true,
-                         zip = true,
+                         zip = false,
                          log = function (msg) {
                          }
                      }) {
@@ -391,7 +391,7 @@ function convert2xkt({
                     stats.minTileSize = minTileSize || 200;
                     stats.sourceSize = (sourceFileSizeBytes / 1000).toFixed(2);
                     stats.xktSize = (targetFileSizeBytes / 1000).toFixed(2);
-                    stats.xktVersion = zip ? 10 : XKT_INFO.xktVersion;
+                    stats.xktVersion = XKT_INFO.xktVersion;
                     stats.compressionRatio = (sourceFileSizeBytes / targetFileSizeBytes).toFixed(2);
                     stats.conversionTime = ((new Date() - startTime) / 1000.0).toFixed(2);
                     stats.aabb = xktModel.aabb;

--- a/src/parsers/parseGLTFIntoXKTModel.js
+++ b/src/parsers/parseGLTFIntoXKTModel.js
@@ -630,11 +630,17 @@ function parseNodeMesh(node, ctx, matrix, meshIds) {
                 const geometryId = createPrimitiveHash(primitive);
                 if (!ctx.geometriesCreated[geometryId]) {
                     const geometryCfg = {
-                        geometryId
+                        geometryId,
+                        axisLabel: "",
                     };
                     switch (primitive.mode) {
                         case 0: // POINTS
-                            geometryCfg.primitiveType = "points";
+                            if(primitive.extras?.IfcAxisLabel){
+                                geometryCfg.primitiveType = "axis-label";
+                                geometryCfg.axisLabel = primitive.extras.IfcAxisLabel;
+                            }
+                            else
+                                geometryCfg.primitiveType = "points";
                             break;
                         case 1: // LINES
                             geometryCfg.primitiveType = "lines";


### PR DESCRIPTION
Updated Gltf2XKTConver to:
- process extras attribute for IfcAxisLabels
- Output uncompressed files by default
- Add option to compress files
- Update parser version