### PR TITLE
chore: add TS types to export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xeokit/xeokit-convert",
-  "version": "1.2.0",
+  "version": "1.2.1-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xeokit/xeokit-convert",
-      "version": "1.2.0",
+      "version": "1.2.1-beta.3",
       "license": "LICENSE",
       "dependencies": {
         "@loaders.gl/core": "^4.3.3",
@@ -18,6 +18,7 @@
         "@loaders.gl/ply": "^4.3.3",
         "@loaders.gl/polyfills": "^4.3.3",
         "@loaders.gl/textures": "^4.3.3",
+        "@xeokit/xeokit-convert": "^1.2.0",
         "commander": "^11.0.0",
         "pako": "^2.1.0",
         "web-ifc": "0.0.68"
@@ -29,7 +30,8 @@
         "esdoc": "^1.1.0",
         "esdoc-node": "^1.0.5",
         "esdoc-standard-plugin": "^1.0.0",
-        "rimraf": "^3.0.2"
+        "rimraf": "^3.0.2",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@babel/runtime": {
@@ -319,10 +321,31 @@
       "integrity": "sha512-EI413MkWKBDVNIfLdqbeNSJTs7ToBz/KVGkwi3D+dQrSIkRI2IYbWGAU3xX+D6+CI4ls8ehxMhNpUVMaZggDvQ==",
       "license": "MIT"
     },
+    "node_modules/@typeonly/loader": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@typeonly/loader/-/loader-0.5.4.tgz",
+      "integrity": "sha512-rB5lLT1wxIPr5+kyv98GbtzVVXtvGE9P4G03YOf2v2m+sRZNbrTF0jCyA53DxXPq5+eRoFPFs/+jE5TbAAEnNQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/@typeonly/validator": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@typeonly/validator/-/validator-0.5.2.tgz",
+      "integrity": "sha512-xmVz8RK9jRZYnRP/jbD6TVV2CpyuynB/NvZTfJHGDB8C9BXBH9zgYuoMD4rFdefIV9uJhzv6MCslocADcfDMWg==",
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@typeonly/loader": "^0.5.4"
+      }
+    },
     "node_modules/@types/crypto-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
       "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/flatbuffers": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@types/flatbuffers/-/flatbuffers-1.10.3.tgz",
+      "integrity": "sha512-kwJQsAROanCiMXSLjcTLmYVBIJ9Qyuqs92SaDIcj2EII2KnDgZbiU7it1Z/JfZd1gmxw/lAahMysQ6ZM+j3Ryw==",
       "license": "MIT"
     },
     "node_modules/@types/geojson": {
@@ -336,6 +359,300 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
       "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==",
       "dev": true
+    },
+    "node_modules/@types/text-encoding-utf-8": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/text-encoding-utf-8/-/text-encoding-utf-8-1.0.5.tgz",
+      "integrity": "sha512-TvFzTUXYoNECsORUpuuvKoU4/bsOBto2m8U38Cy8LOG9+BAgvMfwV9jV/vouocSYvgNzWrUfJeZ1rkGIrJgnvA==",
+      "license": "MIT"
+    },
+    "node_modules/@xeokit/xeokit-convert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xeokit/xeokit-convert/-/xeokit-convert-1.2.0.tgz",
+      "integrity": "sha512-t554qJJtGfPa9m30v3rlbkRrHOPe3xMpSX9lIuf6g4h8JkNsHSprDO5yIZTl7dPvkD5suN8fUpV1nhHEx0jCwA==",
+      "license": "LICENSE",
+      "dependencies": {
+        "@loaders.gl/core": "^3.2.6",
+        "@loaders.gl/gltf": "^3.2.6",
+        "@loaders.gl/images": "^3.2.6",
+        "@loaders.gl/json": "^3.2.6",
+        "@loaders.gl/las": "^3.2.6",
+        "@loaders.gl/obj": "^3.2.6",
+        "@loaders.gl/ply": "^3.2.6",
+        "@loaders.gl/polyfills": "^3.2.6",
+        "@loaders.gl/textures": "^3.2.6",
+        "@typeonly/validator": "^0.5.2",
+        "commander": "^11.0.0",
+        "core-js": "^3.22.5",
+        "fs": "0.0.1-security",
+        "pako": "^2.0.4",
+        "path": "^0.12.7",
+        "web-ifc": "0.0.40"
+      },
+      "bin": {
+        "xeokit-convert": "convert2xkt.js"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/core": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.4.15.tgz",
+      "integrity": "sha512-rPOOTuusWlRRNMWg7hymZBoFmPCXWThsA5ZYRfqqXnsgVeQIi8hzcAhJ7zDUIFAd/OSR8ravtqb0SH+3k6MOFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.4.15",
+        "@loaders.gl/worker-utils": "3.4.15",
+        "@probe.gl/log": "^3.5.0"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/draco": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.4.15.tgz",
+      "integrity": "sha512-SStmyP0ZnS4JbWZb2NhrfiHW65uy3pVTTzQDTgXfkR5cD9oDAEu4nCaHbQ8x38/m39FHliCPgS9b1xWvLKQo8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.4.15",
+        "@loaders.gl/schema": "3.4.15",
+        "@loaders.gl/worker-utils": "3.4.15",
+        "draco3d": "1.5.5"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/gis": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.4.15.tgz",
+      "integrity": "sha512-h+LJI35P6ze8DFPSUylTKuml0l4HIfHMczML6u+ZXG6E2w5tbdM3Eh5AzHjXGQPuwUnaYPn3Mq/2t2N1rz98pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "3.4.15",
+        "@loaders.gl/schema": "3.4.15",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@math.gl/polygon": "^3.5.1",
+        "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/gltf": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.4.15.tgz",
+      "integrity": "sha512-Y6kMNPLiHQPr6aWQw/4BMTxgPHWx3fcib4LPpZCbhyfM8PRn6pOqATVngUXdoOf5XY0QtdKVld6N1kxlr4pJtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/draco": "3.4.15",
+        "@loaders.gl/images": "3.4.15",
+        "@loaders.gl/loader-utils": "3.4.15",
+        "@loaders.gl/textures": "3.4.15",
+        "@math.gl/core": "^3.5.1"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/images": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.4.15.tgz",
+      "integrity": "sha512-QpjYhEetHabY/z9mWZYJXZZp4XJAxa38f9Ii/DjPlnJErepzY5GLBUTDHMu4oZ6n99gGImtuGFicDnFV6mb60g==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "3.4.15"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/json": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/json/-/json-3.4.15.tgz",
+      "integrity": "sha512-3VkvQiVKNt5tRxl867tLOHr3TZ9541D86WPqBzJg/ClQ5C0xBqUzhW9yhNxt3xcsvIPIndQlY5EeSs7M9SfLag==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/gis": "3.4.15",
+        "@loaders.gl/loader-utils": "3.4.15",
+        "@loaders.gl/schema": "3.4.15"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/las": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/las/-/las-3.4.15.tgz",
+      "integrity": "sha512-K983PEXVaVzC4rZtGAqSnMQxVtYyGi27zd5ABIWh8kdDt0RCjxcnfNBL1f3GO7hn3HksndYN6GqdUsztgLa4vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.4.15",
+        "@loaders.gl/schema": "3.4.15",
+        "apache-arrow": "^4.0.0"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/loader-utils": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.4.15.tgz",
+      "integrity": "sha512-uUx6tCaky6QgCRkqCNuuXiUfpTzKV+ZlJOf6C9bKp62lpvFOv9AwqoXmL23j8nfsENdlzsX3vPhc3en6QQyksA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/worker-utils": "3.4.15",
+        "@probe.gl/stats": "^3.5.0"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/obj": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/obj/-/obj-3.4.15.tgz",
+      "integrity": "sha512-mXBrMRyUkRetzSqsl76/RnUiDN7vJwbL07LA5l0cmjQoMMatRHlJKeDjlY3n/x2T9mTM4HkS6zuAAfBrtKsbUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.4.15",
+        "@loaders.gl/schema": "3.4.15"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/ply": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/ply/-/ply-3.4.15.tgz",
+      "integrity": "sha512-Gneghys/l37CZJzxTctDLCUyFoG/B6hySQ4sl03H8Xk0YKOhp7KW+d8MUv1pneD4fgNLeIipBrn1KiswPKuGjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.4.15",
+        "@loaders.gl/schema": "3.4.15"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/polyfills": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/polyfills/-/polyfills-3.4.15.tgz",
+      "integrity": "sha512-mf4IpdERDDcRgFG1phc5UxuD02TnEjiOEbWS/7ooAlNrRJuKgocl6neHIOO6nRX3p+ff5/SbkR+seJfuJS3ftw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@xmldom/xmldom": "^0.7.13",
+        "buffer": "^6.0.3",
+        "get-pixels": "^3.3.2",
+        "ndarray": "^1.0.18",
+        "save-pixels": "^2.3.2",
+        "stream-to-async-iterator": "^0.2.0",
+        "through": "^2.3.8",
+        "web-streams-polyfill": "^3.0.0"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/schema": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.4.15.tgz",
+      "integrity": "sha512-8oRtstz0IsqES7eZd2jQbmCnmExCMtL8T6jWd1+BfmnuyZnQ0B6TNccy++NHtffHdYuzEoQgSELwcdmhSApYew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.7"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/textures": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.4.15.tgz",
+      "integrity": "sha512-QHnmxBYtLvTdG1uMz2KWcxVY8KPb1+XyPJUoZV9GMcQkulz+CwFB8BaX8nROfMDz9KKYoPfksCzjig0LZ0WBJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/images": "3.4.15",
+        "@loaders.gl/loader-utils": "3.4.15",
+        "@loaders.gl/schema": "3.4.15",
+        "@loaders.gl/worker-utils": "3.4.15",
+        "ktx-parse": "^0.0.4",
+        "texture-compressor": "^1.0.2"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@loaders.gl/worker-utils": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.4.15.tgz",
+      "integrity": "sha512-zUUepOYRYmcYIcr/c4Mchox9h5fBFNkD81rsGnLlZyq19QvyHzN+93SVxrLc078gw93t2RKrVcOOZY13zT3t1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@math.gl/core": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-jBABmDkj5uuuE0dTDmwwss7Cup5ZwQ6Qb7h1pgvtkEutTrhkcv8SuItQNXmF45494yIHeoGue08NlyeY6wxq2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@math.gl/types": "3.6.3",
+        "gl-matrix": "^3.4.0"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@math.gl/polygon": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.6.3.tgz",
+      "integrity": "sha512-FivQ1ZnYcAss1wVifOkHP/ZnlfQy1IL/769uzNtiHxwUbW0kZG3yyOZ9I7fwyzR5Hvqt3ErJKHjSYZr0uVlz5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "3.6.3"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@math.gl/types": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-3.6.3.tgz",
+      "integrity": "sha512-3uWLVXHY3jQxsXCr/UCNPSc2BG0hNUljhmOBt9l+lNFDp7zHgm0cK2Tw4kj2XfkJy4TgwZTBGwRDQgWEbLbdTA==",
+      "license": "MIT"
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@probe.gl/env": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-3.6.0.tgz",
+      "integrity": "sha512-4tTZYUg/8BICC3Yyb9rOeoKeijKbZHRXBEKObrfPmX4sQmYB15ZOUpoVBhAyJkOYVAM8EkPci6Uw5dLCwx2BEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@probe.gl/log": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-3.6.0.tgz",
+      "integrity": "sha512-hjpyenpEvOdowgZ1qMeCJxfRD4JkKdlXz0RC14m42Un62NtOT+GpWyKA4LssT0+xyLULCByRAtG2fzZorpIAcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@probe.gl/env": "3.6.0"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/@probe.gl/stats": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.6.0.tgz",
+      "integrity": "sha512-JdALQXB44OP4kUBN/UrQgzbJe4qokbVF4Y8lkIA8iVCFnjVowWIgkD/z/0QO65yELT54tTrtepw1jScjKB+rhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/draco3d": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.5.tgz",
+      "integrity": "sha512-JVuNV0EJzD3LBYhGyIXJLeBID/EVtmFO1ZNhAYflTgiMiAJlbhXQmRRda/azjc8MRVMHh0gqGhiqHUo5dIXM8Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/ktx-parse": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.0.4.tgz",
+      "integrity": "sha512-LY3nrmfXl+wZZdPxgJ3ZmLvG+wkOZZP3/dr4RbQj1Pk3Qwz44esOOSFFVQJcNWpXAtiNIC66WgXufX/SYgYz6A==",
+      "license": "MIT"
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/stream-to-async-iterator": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-async-iterator/-/stream-to-async-iterator-0.2.0.tgz",
+      "integrity": "sha512-ACcmP5IdGSq9cIENmcLl+Xe7g3fXIDoxT8p4RwsEakMLG5NZXTg/v+aO9Lu288lFXrou3ubYW+hNGO54HE4t2w==",
+      "license": "MIT"
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/web-ifc": {
+      "version": "0.0.40",
+      "resolved": "https://registry.npmjs.org/web-ifc/-/web-ifc-0.0.40.tgz",
+      "integrity": "sha512-/lmogVLudvTjrWwxyfPywx6G1iWz2UAlhO1n8HVin188k4u54Cq2RpESmypj3EzsiJzgfON5Suq6xgbRuB25Bg=="
+    },
+    "node_modules/@xeokit/xeokit-convert/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "deprecated": "this version is no longer supported, please update to at least 0.8.*",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/abab": {
       "version": "1.0.4",
@@ -380,6 +697,54 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/apache-arrow": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-4.0.1.tgz",
+      "integrity": "sha512-DyF7GXCbSjsw4P5C8b+qW7OnJKa6w9mJI0mhV0+EfZbVZCmhfiF6ffqcnrI/kzBrRqn9hH/Ft9n5+m4DTbBJpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/flatbuffers": "^1.10.0",
+        "@types/node": "^14.14.37",
+        "@types/text-encoding-utf-8": "^1.0.1",
+        "command-line-args": "5.1.1",
+        "command-line-usage": "6.1.1",
+        "flatbuffers": "1.12.0",
+        "json-bignum": "^0.0.3",
+        "pad-left": "^2.1.0",
+        "text-encoding-utf-8": "^1.0.2",
+        "tslib": "^2.2.0"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/asn1": {
@@ -694,6 +1059,20 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/cheerio": {
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
@@ -711,11 +1090,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
     "node_modules/color-logger": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/color-logger/-/color-logger-0.0.6.tgz",
       "integrity": "sha512-0iBj3eHRYnor8EJi3oQ1kixbr7B2Sbw1InxjsYZxS+q2H+Ii69m3ARYSJeYIqmf/QRtFhWnR1v97wp8N7ABubw==",
       "dev": true
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -726,6 +1120,54 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+      "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.1",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/commander": {
@@ -773,6 +1215,17 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+    },
+    "node_modules/core-js": {
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.42.0.tgz",
+      "integrity": "sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -840,6 +1293,15 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-0.0.3.tgz",
       "integrity": "sha512-Cp+jOa8QJef5nXS5hU7M1DWzXPEIoVR3kbV0dQuVGwROZg8bGf1DcCnkmajBTnvghTtSNMUdRrPjgaT6ZQucbw=="
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -934,7 +1396,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -1357,6 +1818,24 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
+      "license": "SEE LICENSE IN LICENSE.txt"
+    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1377,6 +1856,12 @@
       "engines": {
         "node": ">= 0.12"
       }
+    },
+    "node_modules/fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
+      "license": "ISC"
     },
     "node_modules/fs-extra": {
       "version": "5.0.0",
@@ -1453,6 +1938,12 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
+    "node_modules/gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
+      "license": "MIT"
+    },
     "node_modules/glm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glm/-/glm-1.0.0.tgz",
@@ -1527,6 +2018,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/htmlparser2": {
@@ -1791,6 +2291,14 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -1881,6 +2389,12 @@
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
       "integrity": "sha512-lxdsn7xxlCymgLYo1gGvVrfHmkjDiyqVv62FAeF2i5ta72BipE1SLxw8hPEPLhD4/247Ijw07UQH7Hq/chT5LA==",
       "dev": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -2093,6 +2607,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pad-left": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
+      "integrity": "sha512-HJxs9K9AztdIQIAIa/OIazRAUW/L6B9hbQDxO4X07roW3eo9XqZc2ur9bn1StH9CnbbI9EgvejHQX7CBpCF1QA==",
+      "license": "MIT",
+      "dependencies": {
+        "repeat-string": "^1.5.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
@@ -2113,6 +2639,16 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
       }
     },
     "node_modules/path-is-absolute": {
@@ -2169,6 +2705,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
@@ -2210,10 +2755,28 @@
         "node": ">= 6"
       }
     },
+    "node_modules/reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/repeating": {
       "version": "2.0.1",
@@ -2390,6 +2953,18 @@
         }
       ]
     },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -2397,11 +2972,49 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/taffydb": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.3.tgz",
       "integrity": "sha512-GQ3gtYFSOAxSMN/apGtDKKkbJf+8izz5YfbGqIsUc7AMiQOapARZ76dhilRY2h39cynYxBFdafQo5HUL5vgkrg==",
       "dev": true
+    },
+    "node_modules/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
     "node_modules/texture-compressor": {
       "version": "1.0.2",
@@ -2458,6 +3071,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -2487,6 +3106,29 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -2509,11 +3151,26 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "license": "ISC"
     },
     "node_modules/uuid": {
       "version": "3.4.0",
@@ -2579,6 +3236,28 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "license": "MIT",
+      "dependencies": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/wordwrapjs/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
   "name": "@xeokit/xeokit-convert",
-  "version": "1.2.1",
+  "version": "1.2.1-beta.5",
   "description": "JavaScript utilities to create .XKT files",
   "main": "index.js",
+  "types": "./types/index.d.ts",
   "bin": {
     "xeokit-convert": "convert2xkt.js"
   },
   "directories": {},
   "scripts": {
-    "build": "npm run docs",
-    "docs": "rimraf ./docs/* && npx esdoc"
+    "build": "npm run docs && npm run types",
+    "docs": "rimraf ./docs/* && npx esdoc",
+    "types": "tsc"
   },
   "repository": {
     "type": "git",
@@ -17,7 +19,26 @@
   },
   "exports": {
     ".": {
-      "import": "./src/index.js"
+      "import": "./src/index.js",
+      "require": "./src/index.js",
+      "types": "./types/index.d.ts"
+    },
+    "./convert2xkt.conf.js": "./convert2xkt.conf.js",
+    "./convert2xkt.conf.json": "./convert2xkt.conf.json",
+    "./convert2xkt.js": {
+      "import": "./convert2xkt.js",
+      "require": "./convert2xkt.js",
+      "types": "./types/convert2xkt.d.ts"
+    },
+    "./src/index.js": {
+      "import": "./src/index.js",
+      "require": "./src/index.js",
+      "types": "./types/index.d.ts"
+    },
+    "./src/convert2xkt.js": {
+      "import": "./src/convert2xkt.js",
+      "require": "./src/convert2xkt.js",
+      "types": "./types/convert2xkt.d.ts"
     }
   },
   "type": "module",
@@ -51,6 +72,7 @@
     "@loaders.gl/ply": "^4.3.3",
     "@loaders.gl/polyfills": "^4.3.3",
     "@loaders.gl/textures": "^4.3.3",
+    "@xeokit/xeokit-convert": "^1.2.0",
     "commander": "^11.0.0",
     "pako": "^2.1.0",
     "web-ifc": "0.0.68"
@@ -59,10 +81,12 @@
     "esdoc": "^1.1.0",
     "esdoc-node": "^1.0.5",
     "esdoc-standard-plugin": "^1.0.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "typescript": "^5.8.3"
   },
   "files": [
     "/src",
+    "/types",
     "./convert2xkt.js",
     "./convert2xkt.conf.js",
     "./convert2xkt.conf.json"

--- a/src/convert2xkt.js
+++ b/src/convert2xkt.js
@@ -47,35 +47,37 @@ import path from 'path';
  * @param {Object} [params.WebIFC] The WebIFC library (optional for IFC files). If not provided, the function will
  * try to dynamically import it from 'web-ifc/web-ifc-api-node.js'. Providing it explicitly allows the
  * caller to choose whether to use the Browser or NodeJS version.
- * @param {*} [params.configs] Configurations.
+ * @param {Object} [params.configs={}] Configurations.
  * @param {String} [params.source] Path to source file. Alternative to ````sourceData````.
  * @param {ArrayBuffer|JSON} [params.sourceData] Source file data. Alternative to ````source````.
  * @param {String} [params.sourceFormat] Format of source file/data. Always needed with ````sourceData````, but not normally needed with ````source````, because convert2xkt will determine the format automatically from the file extension of ````source````.
  * @param {String} [params.metaModelDataStr] Source file data. Overrides metadata from ````metaModelSource````, ````sourceData```` and ````source````.
  * @param {String} [params.metaModelSource] Path to source metaModel file. Overrides metadata from ````sourceData```` and ````source````. Overridden by ````metaModelData````.
+ * @param {Object} [params.modelAABB] Optional model axis-aligned bounding box.
  * @param {String} [params.output] Path to destination XKT file. Directories on this path are automatically created if not existing.
  * @param {Function} [params.outputXKTModel] Callback to collect the ````XKTModel```` that is internally build by this method.
  * @param {Function} [params.outputXKT] Callback to collect XKT file data.
  * @param {String[]} [params.includeTypes] Option to only convert objects of these types.
  * @param {String[]} [params.excludeTypes] Option to never convert objects of these types.
- * @param {Object} [stats] Collects conversion statistics. Statistics are attached to this object if provided.
- * @param {Function} [params.outputStats] Callback to collect statistics.
- * @param {Boolean} [params.rotateX=false] Whether to rotate the model 90 degrees about the X axis to make the Y axis "up", if necessary. Applies to CityJSON and LAS/LAZ models.
  * @param {Boolean} [params.reuseGeometries=true] When true, will enable geometry reuse within the XKT. When false,
  * will automatically "expand" all reused geometries into duplicate copies. This has the drawback of increasing the XKT
  * file size (~10-30% for typical models), but can make the model more responsive in the xeokit Viewer, especially if the model
  * has excessive geometry reuse. An example of excessive geometry reuse would be when a model (eg. glTF) has 4000 geometries that are
  * shared amongst 2000 objects, ie. a large number of geometries with a low amount of reuse, which can present a
  * pathological performance case for xeokit's underlying graphics APIs (WebGL, WebGPU etc).
- * @param {Boolean} [params.includeTextures=true] Whether to convert textures. Only works for ````glTF```` models.
- * @param {Boolean} [params.includeNormals=true] Whether to convert normals. When false, the parser will ignore
- * geometry normals, and the modelwill rely on the xeokit ````Viewer```` to automatically generate them. This has
- * the limitation that the normals will be face-aligned, and therefore the ````Viewer```` will only be able to render
- * a flat-shaded non-PBR representation of the model.
  * @param {Number} [params.minTileSize=200] Minimum RTC coordinate tile size. Set this to a value between 100 and 10000,
  * depending on how far from the coordinate origin the model's vertex positions are; specify larger tile sizes when close
- * to the origin, and smaller sizes when distant.  This compensates for decreasing precision as floats get bigger.
- * @param {Function} [params.log] Logging callback.
+ * to the origin, and smaller sizes when distant. This compensates for decreasing precision as floats get bigger.
+ * @param {Object} [params.stats={}] Collects conversion statistics. Statistics are attached to this object if provided.
+ * @param {Function} [params.outputStats] Callback to collect statistics.
+ * @param {Boolean} [params.rotateX=false] Whether to rotate the model 90 degrees about the X axis to make the Y axis "up", if necessary. Applies to CityJSON and LAS/LAZ models.
+ * @param {Boolean} [params.includeTextures=true] Whether to convert textures. Only works for ````glTF```` models.
+ * @param {Boolean} [params.includeNormals=true] Whether to convert normals. When false, the parser will ignore
+ * geometry normals, and the model will rely on the xeokit ````Viewer```` to automatically generate them. This has
+ * the limitation that the normals will be face-aligned, and therefore the ````Viewer```` will only be able to render
+ * a flat-shaded non-PBR representation of the model.
+ * @param {Boolean} [params.zip=false] Whether to zip the XKT output.
+ * @param {Function} [params.log=function(msg){}] Logging callback.
  * @return {Promise<number>}
  */
 function convert2xkt({
@@ -304,7 +306,7 @@ function convert2xkt({
                 if (!WebIFC) {
                     try {
                         // Try to dynamically import WebIFC
-                        import('web-ifc/web-ifc-api-node.js').then((module) => {
+                        import('web-ifc').then((module) => {
                             const WebIFCImported = module.default;
                             convert(parseIFCIntoXKTModel, {
                                 WebIFC: WebIFCImported,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "lib": ["esnext", "dom"],
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./types",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowJs": true,
+    "checkJs": false,
+    "strict": true
+  },
+  "include": ["src/**/*.js"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
-  Add to the package an auto-generated TS types (*.d.ts) - from from JSDoc.
- It will not hurt JS users, and on the other side TS users will not have to add *.d.ts themselves.  