### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
     # Only run this job when *not* publishing a tag
     if: startsWith(github.ref, 'refs/tags/') != true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout source code
@@ -31,6 +33,9 @@ jobs:
   security:
     if: startsWith(github.ref, 'refs/tags/') != true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities


### PR DESCRIPTION
Potential fix for [https://github.com/xeokit/xeokit-convert/security/code-scanning/11](https://github.com/xeokit/xeokit-convert/security/code-scanning/11)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimum required permissions for each job. For the `build` job, the workflow only needs to read the repository contents, so we will set `contents: read`. For the `security` job, which uploads SARIF files and interacts with GitHub Code Scanning, we will add `security-events: write` in addition to `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
